### PR TITLE
'Large Method' Code Smell

### DIFF
--- a/MyClass/GameController.cs
+++ b/MyClass/GameController.cs
@@ -1,10 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
-using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MyClass
 {

--- a/MyClass/GameController.cs
+++ b/MyClass/GameController.cs
@@ -59,40 +59,24 @@ namespace MyClass
                     roads.RemoveAt(i);
                 }
             }
-            for (int i = 0; i < skelets.Count; i++)
-            {
-                skelets[i].position = new PointF(skelets[i].position.X - 7, skelets[i].position.Y);
-                if (skelets[i].position.X + skelets[i].size.Width < 0)
-                {
-                    skelets.RemoveAt(i);
-                }
-            }
-            for (int i = 0; i < birds.Count; i++)
-            {
-                birds[i].position = new PointF(birds[i].position.X - 7, birds[i].position.Y);
-                if (birds[i].position.X + roads[i].size.Width < 0)
-                {
-                    birds.RemoveAt(i);
-                }
-            }
-            for (int i = 0; i < coins.Count; i++)
-            {
-                coins[i].position = new PointF(coins[i].position.X - 7, coins[i].position.Y);
-                if (coins[i].position.X + roads[i].size.Width < 0)
-                {
-                    coins.RemoveAt(i);
-                }
-            }
-            for (int i = 0; i < ghoats.Count; i++)
-            {
-                ghoats[i].position = new PointF(ghoats[i].position.X - 7, ghoats[i].position.Y);
-                if (ghoats[i].position.X + roads[i].size.Width < 0)
-                {
-                    ghoats.RemoveAt(i);
-                }
-            }
-          
 
+
+            MoveEntities(skelets);
+            MoveEntities(birds);
+            MoveEntities(coins);
+            MoveEntities(ghoats);
+        }
+
+        public static void MoveEntities<T>(List<T> Entities) where T : Transform
+        {
+            for (int i = 0; i < Entities.Count; i++)
+            { 
+                Entities[i].position = new PointF(Entities[i].position.X - 7, Entities[i].position.Y);
+                if (Entities[i].position.X + roads[i].size.Width < 0)
+                {
+                    Entities.RemoveAt(i);
+                }
+            }
         }
 
         public static void GetNewRoad()
@@ -152,34 +136,18 @@ namespace MyClass
 
         public static void DrawObjets(Graphics g)
         {
-            for (int i = 0; i < roads.Count; i++)
-            {
-                roads[i].DrawSprite(g);
-            }
-            for (int i = 0; i < skelets.Count; i++)
-            {
-                skelets[i].DrawSprite(g);
-            }
-            for (int i = 0; i < birds.Count; i++)
-            {
-                birds[i].DrawSprite(g);
-            }
-            for (int i = 0; i < ghoats.Count; i++)
-            {
-                ghoats[i].DrawSprite(g);
-            }
-            for (int i = 0; i < coins.Count; i++)
-            {
-                coins[i].DrawSprite(g);
-            }
+            roads.ForEach(road => road.DrawSprite(g));
+            skelets.ForEach(skelet => skelet.DrawSprite(g));
+            birds.ForEach(bird => bird.DrawSprite(g));
+            ghoats.ForEach(ghoat => ghoat.DrawSprite(g));
+            coins.ForEach(coin => coin.DrawSprite(g));
 
             backgroundShift -= 1;
+
             if (backgroundShift <= -back.Width)
             {
                 backgroundShift = 0;
             }
-            
         }
-      
     }
 }

--- a/MyClass/Skelet.cs
+++ b/MyClass/Skelet.cs
@@ -1,15 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MyClass
 {
     public class Skelet : Transform
     {
-
         int srcX = 0;
         int srcY = 0;
         int srcW = 0;
@@ -20,74 +16,48 @@ namespace MyClass
         public Skelet(PointF pos, Size size) : base(pos, size)
         {
 
-
         }
+
+        private struct AnimationFrame
+        {
+            public int SrcX, SrcY, SrcW, SrcH, AnimationCount;
+
+            public AnimationFrame(int SrcX, int SrcY, int SrcW, int SrcH, int AnimationCount)
+            {
+                this.SrcX = SrcX;
+                this.SrcY = SrcY;
+                this.SrcW = SrcW;
+                this.SrcH = SrcH;
+                this.AnimationCount = AnimationCount;
+            }
+        }
+
+        private static readonly List<AnimationFrame> AnimationFrames= new List<AnimationFrame>
+        {
+            new AnimationFrame(340, 240, 90, 60, 0),
+            new AnimationFrame(440, 240, 90, 60, 1),
+            new AnimationFrame(10, 360, 130, 60, 2),
+            new AnimationFrame(140, 330, 100, 90, 3),
+            new AnimationFrame(280, 330, 100, 90, 4),
+            new AnimationFrame(410, 330, 100, 90, 5) 
+        };
 
         public override void DrawSprite(Graphics g)
         {
             frameCount++;
-            if (frameCount <= 500)
-            {
-                srcX = 340;
-                srcY = 240;
-                srcW = 90;
-                srcH = 60;
-                animationCount = 0;
-            }
-            else if (frameCount > 500 && frameCount <= 550)
-            {
-                srcX = 440;
-                srcY = 240;
-                srcW = 90;
-                srcH = 60;
-                animationCount = 1;
-            }
-            else if (frameCount > 550 && frameCount <= 600)
-            {
-                srcX = 10;
-                srcY = 360;
-                srcW = 130;
-                srcH = 60;
-                animationCount = 2;
-            }
-            else if (frameCount > 600 && frameCount <= 650)
-            {
-                srcX = 140;
-                srcY = 330;
-                srcW = 100;
-                srcH = 90;
 
-                animationCount = 3;
-            }
-            else if (frameCount > 650 && frameCount <= 700)
-            {
-                srcX = 280;
-                srcY = 330;
-                srcW = 100;
-                srcH = 90;
-                animationCount = 4;
-            }
-            else if (frameCount > 700 && frameCount <= 750)
-            {
-                srcX = 410;
-                srcY = 330;
-                srcW = 100;
-                srcH = 90;
-                animationCount = 5;
-            }
+            int frameIndex = Math.Min(frameCount / 50, AnimationFrames.Count - 1);
 
-            if (frameCount > 750)
-            {
-                srcX = 410;
-                srcY = 330;
-                srcW = 100;
-                srcH = 90;
-            }
+            var frame = AnimationFrames[frameIndex];
 
+            int srcX = frame.SrcX;
+            int srcY = frame.SrcY;
+            int srcW = frame.SrcW;
+            int srcH = frame.SrcH;
+            int animationCount = frame.AnimationCount;
 
             g.DrawImage(GameController.halloween, new Rectangle((int)position.X, (int)position.Y, (int)size.Width, size.Height),
                 srcX, srcY, srcW, srcH, GraphicsUnit.Pixel);
         }
-
     }
 }


### PR DESCRIPTION
This PR refactors the DrawSprite method to eliminate repetitive if-else conditions for setting the sprite's source rectangle (srcX, srcY, srcW, srcH) based on animation_count The original method had several blocks of redundant code that made it harder to maintain and scale as more frames were added.
### Changes:
* Introduced a List<AnimationFrame> to hold the sprite frame data, including srcX, srcY, srcW, srcH, and the corresponding animation_frame for each frame.
* Replaced the if-else chain with a loop that iterates through the AnimationFrames list and checks which frame corresponds to the current animation_count.
### Implemented changes:
```bash
private static readonly List<AnimationFrame> AnimationFrames= new List<AnimationFrame>
{
    new AnimationFrame(340, 240, 90, 60, 0),
    new AnimationFrame(440, 240, 90, 60, 1),
    new AnimationFrame(10, 360, 130, 60, 2),
    new AnimationFrame(140, 330, 100, 90, 3),
    new AnimationFrame(280, 330, 100, 90, 4),
    new AnimationFrame(410, 330, 100, 90, 5) 
};

public override void DrawSprite(Graphics g)
{
    frameCount++;

    int frameIndex = Math.Min(frameCount / 50, AnimationFrames.Count - 1);

    var frame = AnimationFrames[frameIndex];

    int srcX = frame.SrcX;
    int srcY = frame.SrcY;
    int srcW = frame.SrcW;
    int srcH = frame.SrcH;
    int animationCount = frame.AnimationCount;

    g.DrawImage(GameController.halloween, new Rectangle((int)position.X, (int)position.Y, (int)size.Width, size.Height),
        srcX, srcY, srcW, srcH, GraphicsUnit.Pixel);
}
```

Closes #11 